### PR TITLE
Add thread selection for supergroup messages

### DIFF
--- a/src/components/MessageForm.tsx
+++ b/src/components/MessageForm.tsx
@@ -4,13 +4,23 @@ import { useTelegram } from '../context/TelegramContext';
 import { TelegramChat } from '../types/telegram';
 
 const MessageForm: React.FC = () => {
-  const { token, chats, sendTextMessage, sendImageMessage, loading, error, selectedChatId } = useTelegram();
+  const {
+    token,
+    chats,
+    sendTextMessage,
+    sendImageMessage,
+    loading,
+    error,
+    selectedChatId,
+    forumTopics,
+  } = useTelegram();
   const [message, setMessage] = useState('');
   const [caption, setCaption] = useState('');
   const [image, setImage] = useState<File | null>(null);
   const [messageType, setMessageType] = useState<'text' | 'image'>('text');
   const [success, setSuccess] = useState<string | null>(null);
   const [manualChatId, setManualChatId] = useState('');
+  const [threadId, setThreadId] = useState('');
   
   if (!token) {
     return null;
@@ -25,10 +35,12 @@ const MessageForm: React.FC = () => {
     try {
       let result;
       
+      const thread = threadId ? parseInt(threadId, 10) : undefined;
+
       if (messageType === 'text') {
-        result = await sendTextMessage(targetId, message);
+        result = await sendTextMessage(targetId, message, thread);
       } else if (messageType === 'image' && image) {
-        result = await sendImageMessage(targetId, image, caption);
+        result = await sendImageMessage(targetId, image, caption, thread);
       }
       
       if (result && result.ok) {
@@ -37,6 +49,7 @@ const MessageForm: React.FC = () => {
         setCaption('');
         setImage(null);
         setManualChatId('');
+        setThreadId('');
         
         setTimeout(() => {
           setSuccess(null);
@@ -112,6 +125,33 @@ const MessageForm: React.FC = () => {
             placeholder="@channel or -1001234567890"
           />
         </div>
+
+        {/* Thread Selection for Supergroups */}
+        {selectedChat && selectedChat.type === 'supergroup' && (
+          <div>
+            <label htmlFor="thread-id" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Thread ID (optional)
+            </label>
+            <input
+              type="number"
+              id="thread-id"
+              list="thread-options"
+              value={threadId}
+              onChange={(e) => setThreadId(e.target.value)}
+              className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+              placeholder="Select or enter a thread ID"
+            />
+            {forumTopics[selectedChat.id] && forumTopics[selectedChat.id].length > 0 && (
+              <datalist id="thread-options">
+                {forumTopics[selectedChat.id].map((topic) => (
+                  <option key={topic.message_thread_id} value={topic.message_thread_id}>
+                    {topic.name ? topic.name : `Thread ${topic.message_thread_id}`}
+                  </option>
+                ))}
+              </datalist>
+            )}
+          </div>
+        )}
 
         {/* Message Type Selection */}
         <div>

--- a/src/context/TelegramContext.tsx
+++ b/src/context/TelegramContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useState, useContext, ReactNode, useEffect } from 'react';
-import { TelegramBot, TelegramChat, SendMessageResponse, StoredToken } from '../types/telegram';
+import { TelegramBot, TelegramChat, SendMessageResponse, StoredToken, ForumTopic } from '../types/telegram';
 
 interface TelegramContextType {
   token: string;
@@ -20,8 +20,9 @@ interface TelegramContextType {
   selectStoredToken: (token: string) => void;
   verifyToken: (token: string) => Promise<boolean>;
   fetchChats: () => Promise<void>;
-  sendTextMessage: (chatId: number | string, text: string) => Promise<SendMessageResponse | null>;
-  sendImageMessage: (chatId: number | string, image: File, caption?: string) => Promise<SendMessageResponse | null>;
+  sendTextMessage: (chatId: number | string, text: string, threadId?: number) => Promise<SendMessageResponse | null>;
+  sendImageMessage: (chatId: number | string, image: File, caption?: string, threadId?: number) => Promise<SendMessageResponse | null>;
+  forumTopics: Record<number, ForumTopic[]>;
   clearData: () => void;
 }
 
@@ -37,6 +38,7 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
   const [error, setError] = useState<string | null>(null);
   const [selectedChatId, setSelectedChatId] = useState<number | null>(null);
   const [storedTokens, setStoredTokens] = useState<StoredToken[]>([]);
+  const [forumTopics, setForumTopics] = useState<Record<number, ForumTopic[]>>({});
 
   // Load stored tokens on mount
   useEffect(() => {
@@ -133,16 +135,30 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
         return;
       }
       
-      // Extract unique chats from updates
+      // Extract unique chats from updates and collect forum topics
       const uniqueChats = new Map<number, TelegramChat>();
-      
+      const topicsMap: Record<number, ForumTopic[]> = { ...forumTopics };
+
       data.result.forEach((update: any) => {
         if (update.message && update.message.chat) {
-          uniqueChats.set(update.message.chat.id, update.message.chat);
+          const chat = update.message.chat;
+          uniqueChats.set(chat.id, chat);
+
+          if (update.message.message_thread_id) {
+            const threadId = update.message.message_thread_id as number;
+            const name = update.message.forum_topic_created?.name as string | undefined;
+            if (!topicsMap[chat.id]) {
+              topicsMap[chat.id] = [];
+            }
+            if (!topicsMap[chat.id].some(t => t.message_thread_id === threadId)) {
+              topicsMap[chat.id].push({ message_thread_id: threadId, name });
+            }
+          }
         }
       });
-      
+
       setChats(Array.from(uniqueChats.values()));
+      setForumTopics(topicsMap);
       setLoading(false);
     } catch (error) {
       setError('Failed to fetch chats');
@@ -150,7 +166,11 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
     }
   };
 
-  const sendTextMessage = async (chatId: number | string, text: string): Promise<SendMessageResponse | null> => {
+  const sendTextMessage = async (
+    chatId: number | string,
+    text: string,
+    threadId?: number,
+  ): Promise<SendMessageResponse | null> => {
     if (!token) {
       setError('No token provided');
       return null;
@@ -168,6 +188,7 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
         body: JSON.stringify({
           chat_id: chatId,
           text: text,
+          ...(threadId ? { message_thread_id: threadId } : {}),
         }),
       });
       
@@ -187,7 +208,12 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
     }
   };
 
-  const sendImageMessage = async (chatId: number | string, image: File, caption?: string): Promise<SendMessageResponse | null> => {
+  const sendImageMessage = async (
+    chatId: number | string,
+    image: File,
+    caption?: string,
+    threadId?: number,
+  ): Promise<SendMessageResponse | null> => {
     if (!token) {
       setError('No token provided');
       return null;
@@ -200,9 +226,12 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
       const formData = new FormData();
       formData.append('chat_id', chatId.toString());
       formData.append('photo', image);
-      
+
       if (caption) {
         formData.append('caption', caption);
+      }
+      if (threadId) {
+        formData.append('message_thread_id', threadId.toString());
       }
       
       const response = await fetch(`https://api.telegram.org/bot${token}/sendPhoto`, {
@@ -257,6 +286,7 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
         fetchChats,
         sendTextMessage,
         sendImageMessage,
+        forumTopics,
         clearData,
       }}
     >

--- a/src/types/telegram.ts
+++ b/src/types/telegram.ts
@@ -38,6 +38,7 @@ export interface SendMessageParams {
   chat_id: number | string;
   text: string;
   parse_mode?: 'HTML' | 'MarkdownV2' | 'Markdown';
+  message_thread_id?: number;
 }
 
 export interface SendPhotoParams {
@@ -45,6 +46,7 @@ export interface SendPhotoParams {
   photo: File;
   caption?: string;
   parse_mode?: 'HTML' | 'MarkdownV2' | 'Markdown';
+  message_thread_id?: number;
 }
 
 export interface SendMessageResponse {
@@ -63,4 +65,9 @@ export interface StoredToken {
   token: string;
   botInfo: TelegramBot;
   addedAt: number;
+}
+
+export interface ForumTopic {
+  message_thread_id: number;
+  name?: string;
 }


### PR DESCRIPTION
## Summary
- support sending messages to specific threads
- track supergroup threads from updates
- expose forum topics in Telegram context
- allow choosing thread ID in MessageForm

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_685175e128188330872ce4cbcf905b1b