### PR TITLE
Add thread selection for supergroup messages

### DIFF
--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -11,7 +11,7 @@ const ChatList: React.FC = () => {
     if (token) {
       fetchChats();
     }
-  }, [token]);
+  }, [token, fetchChats]);
 
   const getChatTypeIcon = (type: string) => {
     switch (type) {

--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -101,6 +101,16 @@ const ChatList: React.FC = () => {
           Groups
         </button>
         <button
+          onClick={() => setFilter('supergroup')}
+          className={`py-2 px-3 text-sm font-medium transition-colors duration-200 border-b-2 -mb-px ${
+            filter === 'supergroup'
+              ? 'text-blue-600 dark:text-blue-400 border-blue-600 dark:border-blue-400'
+              : 'text-gray-500 dark:text-gray-400 border-transparent hover:text-gray-700 dark:hover:text-gray-300'
+          }`}
+        >
+          Supergroups
+        </button>
+        <button
           onClick={() => setFilter('channel')}
           className={`py-2 px-3 text-sm font-medium transition-colors duration-200 border-b-2 -mb-px ${
             filter === 'channel'

--- a/src/components/MessageForm.tsx
+++ b/src/components/MessageForm.tsx
@@ -12,6 +12,7 @@ const MessageForm: React.FC = () => {
     loading,
     error,
     selectedChatId,
+    setSelectedChatId,
     forumTopics,
   } = useTelegram();
   const [message, setMessage] = useState('');
@@ -21,6 +22,7 @@ const MessageForm: React.FC = () => {
   const [success, setSuccess] = useState<string | null>(null);
   const [manualChatId, setManualChatId] = useState('');
   const [threadId, setThreadId] = useState('');
+  const [sendMethod, setSendMethod] = useState<'list' | 'custom'>('list');
   
   if (!token) {
     return null;
@@ -29,7 +31,7 @@ const MessageForm: React.FC = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
-    const targetId = manualChatId || selectedChatId;
+    const targetId = sendMethod === 'custom' ? manualChatId : selectedChatId;
     if (!targetId) return;
     
     try {
@@ -96,38 +98,76 @@ const MessageForm: React.FC = () => {
       )}
       
       <form onSubmit={handleSubmit} className="space-y-4">
+        {/* Send Method */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Send Method</label>
+          <div className="flex space-x-2">
+            <button
+              type="button"
+              onClick={() => {
+                setSendMethod('list');
+                setManualChatId('');
+              }}
+              className={`flex-1 py-2 px-4 rounded-md transition-colors duration-200 ${
+                sendMethod === 'list'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200'
+              }`}
+            >
+              From Chat List
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setSendMethod('custom');
+                setSelectedChatId(null);
+              }}
+              className={`flex-1 py-2 px-4 rounded-md transition-colors duration-200 ${
+                sendMethod === 'custom'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200'
+              }`}
+            >
+              Custom User
+            </button>
+          </div>
+        </div>
         {/* Selected Chat Info */}
-        {selectedChat ? (
-          <div className="bg-blue-50 dark:bg-blue-900/20 p-3 rounded-md">
-            <p className="text-sm text-blue-700 dark:text-blue-300">
-              Sending to: <span className="font-medium">{selectedChat.title || selectedChat.username || `${selectedChat.first_name || ''} ${selectedChat.last_name || ''}`.trim() || `Chat ${selectedChat.id}`}</span>
-            </p>
-          </div>
-        ) : (
-          <div className="bg-yellow-50 dark:bg-yellow-900/20 p-3 rounded-md">
-            <p className="text-sm text-yellow-700 dark:text-yellow-300">
-              Please select a chat from the list above to send a message
-            </p>
-          </div>
+        {sendMethod === 'list' && (
+          selectedChat ? (
+            <div className="bg-blue-50 dark:bg-blue-900/20 p-3 rounded-md">
+              <p className="text-sm text-blue-700 dark:text-blue-300">
+                Sending to: <span className="font-medium">{selectedChat.title || selectedChat.username || `${selectedChat.first_name || ''} ${selectedChat.last_name || ''}`.trim() || `Chat ${selectedChat.id}`}</span>
+              </p>
+            </div>
+          ) : (
+            <div className="bg-yellow-50 dark:bg-yellow-900/20 p-3 rounded-md">
+              <p className="text-sm text-yellow-700 dark:text-yellow-300">
+                Please select a chat from the list above to send a message
+              </p>
+            </div>
+          )
         )}
 
         {/* Manual Chat ID */}
-        <div>
-          <label htmlFor="manual-chat" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-            Chat ID or Username
-          </label>
-          <input
-            type="text"
-            id="manual-chat"
-            value={manualChatId}
-            onChange={(e) => setManualChatId(e.target.value)}
-            className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
-            placeholder="@channel or -1001234567890"
-          />
-        </div>
+        {sendMethod === 'custom' && (
+          <div>
+            <label htmlFor="manual-chat" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Chat ID or Username
+            </label>
+            <input
+              type="text"
+              id="manual-chat"
+              value={manualChatId}
+              onChange={(e) => setManualChatId(e.target.value)}
+              className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+              placeholder="@channel or -1001234567890"
+            />
+          </div>
+        )}
 
         {/* Thread Selection for Supergroups */}
-        {selectedChat && selectedChat.type === 'supergroup' && (
+        {sendMethod === 'list' && selectedChat && selectedChat.type === 'supergroup' && (
           <div>
             <label htmlFor="thread-id" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Thread ID (optional)
@@ -272,9 +312,14 @@ const MessageForm: React.FC = () => {
         <div>
           <button
             type="submit"
-            disabled={loading || !(manualChatId || selectedChatId) || (messageType === 'text' && !message) || (messageType === 'image' && !image)}
+            disabled={
+              loading ||
+              (sendMethod === 'custom' ? !manualChatId : !selectedChatId) ||
+              (messageType === 'text' && !message) ||
+              (messageType === 'image' && !image)
+            }
             className={`w-full flex justify-center items-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white ${
-              loading || !selectedChatId || (messageType === 'text' && !message) || (messageType === 'image' && !image)
+              loading || (sendMethod === 'custom' ? !manualChatId : !selectedChatId) || (messageType === 'text' && !message) || (messageType === 'image' && !image)
                 ? 'bg-blue-400 cursor-not-allowed'
                 : 'bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500'
             } transition-colors duration-200`}

--- a/src/components/MessageForm.tsx
+++ b/src/components/MessageForm.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { Send, Image, Trash, Check, AlertCircle } from 'lucide-react';
 import { useTelegram } from '../context/TelegramContext';
-import { TelegramChat } from '../types/telegram';
 
 const MessageForm: React.FC = () => {
   const {
@@ -172,24 +171,23 @@ const MessageForm: React.FC = () => {
             <label htmlFor="thread-id" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Thread ID (optional)
             </label>
-            <input
-              type="number"
+            <select
               id="thread-id"
-              list="thread-options"
               value={threadId}
               onChange={(e) => setThreadId(e.target.value)}
               className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
-              placeholder="Select or enter a thread ID"
-            />
-            {forumTopics[selectedChat.id] && forumTopics[selectedChat.id].length > 0 && (
-              <datalist id="thread-options">
-                {forumTopics[selectedChat.id].map((topic) => (
+            >
+              <option value="">No thread</option>
+              {forumTopics[selectedChat.id] && forumTopics[selectedChat.id].length > 0 ? (
+                forumTopics[selectedChat.id].map((topic) => (
                   <option key={topic.message_thread_id} value={topic.message_thread_id}>
-                    {topic.name ? topic.name : `Thread ${topic.message_thread_id}`}
+                    {topic.name ? `${topic.name} (${topic.message_thread_id})` : `Thread ${topic.message_thread_id}`}
                   </option>
-                ))}
-              </datalist>
-            )}
+                ))
+              ) : (
+                <option disabled>No threads found</option>
+              )}
+            </select>
           </div>
         )}
 

--- a/src/components/MessageForm.tsx
+++ b/src/components/MessageForm.tsx
@@ -181,7 +181,7 @@ const MessageForm: React.FC = () => {
               {forumTopics[selectedChat.id] && forumTopics[selectedChat.id].length > 0 ? (
                 forumTopics[selectedChat.id].map((topic) => (
                   <option key={topic.message_thread_id} value={topic.message_thread_id}>
-                    {topic.name ? `${topic.name} (${topic.message_thread_id})` : `Thread ${topic.message_thread_id}`}
+                    {topic.name ? `${topic.name} (${topic.message_thread_id})` : `Thread ${topic.message_thread_id} - ${topic.title}`}
                   </option>
                 ))
               ) : (

--- a/src/components/MessageForm.tsx
+++ b/src/components/MessageForm.tsx
@@ -4,13 +4,23 @@ import { useTelegram } from '../context/TelegramContext';
 import { TelegramChat } from '../types/telegram';
 
 const MessageForm: React.FC = () => {
-  const { token, chats, sendTextMessage, sendImageMessage, loading, error, selectedChatId } = useTelegram();
+  const {
+    token,
+    chats,
+    sendTextMessage,
+    sendImageMessage,
+    loading,
+    error,
+    selectedChatId,
+    forumTopics,
+  } = useTelegram();
   const [message, setMessage] = useState('');
   const [caption, setCaption] = useState('');
   const [image, setImage] = useState<File | null>(null);
   const [messageType, setMessageType] = useState<'text' | 'image'>('text');
   const [success, setSuccess] = useState<string | null>(null);
   const [manualChatId, setManualChatId] = useState('');
+  const [threadId, setThreadId] = useState('');
   
   if (!token) {
     return null;
@@ -25,10 +35,12 @@ const MessageForm: React.FC = () => {
     try {
       let result;
       
+      const thread = threadId ? parseInt(threadId, 10) : undefined;
+
       if (messageType === 'text') {
-        result = await sendTextMessage(targetId, message);
+        result = await sendTextMessage(targetId, message, thread);
       } else if (messageType === 'image' && image) {
-        result = await sendImageMessage(targetId, image, caption);
+        result = await sendImageMessage(targetId, image, caption, thread);
       }
       
       if (result && result.ok) {
@@ -37,6 +49,7 @@ const MessageForm: React.FC = () => {
         setCaption('');
         setImage(null);
         setManualChatId('');
+        setThreadId('');
         
         setTimeout(() => {
           setSuccess(null);
@@ -112,6 +125,33 @@ const MessageForm: React.FC = () => {
             placeholder="@channel or -1001234567890"
           />
         </div>
+
+        {/* Thread Selection for Supergroups */}
+        {selectedChat && selectedChat.type === 'supergroup' && (
+          <div>
+            <label htmlFor="thread-id" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Thread ID (optional)
+            </label>
+            <input
+              type="number"
+              id="thread-id"
+              list="thread-options"
+              value={threadId}
+              onChange={(e) => setThreadId(e.target.value)}
+              className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+              placeholder="Select or enter a thread ID"
+            />
+            {forumTopics[selectedChat.id] && forumTopics[selectedChat.id].length > 0 && (
+              <datalist id="thread-options">
+                {forumTopics[selectedChat.id].map((topic) => (
+                  <option key={topic.message_thread_id} value={topic.message_thread_id}>
+                    {topic.name ? topic.name : `Thread ${topic.message_thread_id}`}
+                  </option>
+                ))}
+              </datalist>
+            )}
+          </div>
+        )}
 
         {/* Message Type Selection */}
         <div>

--- a/src/components/TokenInput.tsx
+++ b/src/components/TokenInput.tsx
@@ -1,26 +1,23 @@
 import React, { useState } from 'react';
-import { Bot, Key, Check, AlertCircle, Trash2, RefreshCw } from 'lucide-react';
+import { Bot, Key, AlertCircle, Trash2, RefreshCw } from 'lucide-react';
 import { useTelegram } from '../context/TelegramContext';
 import { StoredToken } from '../types/telegram';
 
 const TokenInput: React.FC = () => {
-  const { 
-    verifyToken, 
-    loading, 
-    error, 
-    botInfo, 
-    storedTokens, 
-    removeStoredToken, 
+  const {
+    verifyToken,
+    loading,
+    error,
+    storedTokens,
+    removeStoredToken,
     selectStoredToken,
-    token: currentToken 
+    token: currentToken
   } = useTelegram();
   const [token, setToken] = useState('');
-  const [isVerified, setIsVerified] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const success = await verifyToken(token);
-    setIsVerified(success);
     if (success) {
       setToken('');
     }

--- a/src/context/TelegramContext.tsx
+++ b/src/context/TelegramContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useState, useContext, ReactNode, useEffect } from 'react';
-import { TelegramBot, TelegramChat, SendMessageResponse, StoredToken } from '../types/telegram';
+import { TelegramBot, TelegramChat, SendMessageResponse, StoredToken, ForumTopic } from '../types/telegram';
 
 interface TelegramContextType {
   token: string;
@@ -20,8 +20,9 @@ interface TelegramContextType {
   selectStoredToken: (token: string) => void;
   verifyToken: (token: string) => Promise<boolean>;
   fetchChats: () => Promise<void>;
-  sendTextMessage: (chatId: number | string, text: string) => Promise<SendMessageResponse | null>;
-  sendImageMessage: (chatId: number | string, image: File, caption?: string) => Promise<SendMessageResponse | null>;
+  sendTextMessage: (chatId: number | string, text: string, threadId?: number) => Promise<SendMessageResponse | null>;
+  sendImageMessage: (chatId: number | string, image: File, caption?: string, threadId?: number) => Promise<SendMessageResponse | null>;
+  forumTopics: Record<number, ForumTopic[]>;
   clearData: () => void;
 }
 
@@ -37,6 +38,7 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
   const [error, setError] = useState<string | null>(null);
   const [selectedChatId, setSelectedChatId] = useState<number | null>(null);
   const [storedTokens, setStoredTokens] = useState<StoredToken[]>([]);
+  const [forumTopics, setForumTopics] = useState<Record<number, ForumTopic[]>>({});
 
   // Load stored tokens on mount
   useEffect(() => {
@@ -133,16 +135,30 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
         return;
       }
       
-      // Extract unique chats from updates
+      // Extract unique chats from updates and collect forum topics
       const uniqueChats = new Map<number, TelegramChat>();
-      
+      const topicsMap: Record<number, ForumTopic[]> = { ...forumTopics };
+
       data.result.forEach((update: any) => {
         if (update.message && update.message.chat) {
-          uniqueChats.set(update.message.chat.id, update.message.chat);
+          const chat = update.message.chat;
+          uniqueChats.set(chat.id, chat);
+
+          if (update.message.message_thread_id) {
+            const threadId = update.message.message_thread_id as number;
+            const name = update.message.forum_topic_created?.name as string | undefined;
+            if (!topicsMap[chat.id]) {
+              topicsMap[chat.id] = [];
+            }
+            if (!topicsMap[chat.id].some(t => t.message_thread_id === threadId)) {
+              topicsMap[chat.id].push({ message_thread_id: threadId, name });
+            }
+          }
         }
       });
-      
+
       setChats(Array.from(uniqueChats.values()));
+      setForumTopics(topicsMap);
       setLoading(false);
     } catch (error) {
       setError('Failed to fetch chats');
@@ -150,7 +166,11 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
     }
   };
 
-  const sendTextMessage = async (chatId: number | string, text: string): Promise<SendMessageResponse | null> => {
+  const sendTextMessage = async (
+    chatId: number | string,
+    text: string,
+    threadId?: number,
+  ): Promise<SendMessageResponse | null> => {
     if (!token) {
       setError('No token provided');
       return null;
@@ -168,6 +188,7 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
         body: JSON.stringify({
           chat_id: chatId,
           text: text,
+          ...(threadId ? { message_thread_id: threadId } : {}),
         }),
       });
       
@@ -187,7 +208,12 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
     }
   };
 
-  const sendImageMessage = async (chatId: number | string, image: File, caption?: string): Promise<SendMessageResponse | null> => {
+  const sendImageMessage = async (
+    chatId: number | string,
+    image: File,
+    caption?: string,
+    threadId?: number,
+  ): Promise<SendMessageResponse | null> => {
     if (!token) {
       setError('No token provided');
       return null;
@@ -200,9 +226,12 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
       const formData = new FormData();
       formData.append('chat_id', chatId.toString());
       formData.append('photo', image);
-      
+
       if (caption) {
         formData.append('caption', caption);
+      }
+      if (threadId) {
+        formData.append('message_thread_id', threadId.toString());
       }
       
       const response = await fetch(`https://api.telegram.org/bot${token}/sendPhoto`, {
@@ -257,6 +286,7 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
         fetchChats,
         sendTextMessage,
         sendImageMessage,
+        forumTopics,
         clearData,
       }}
     >

--- a/src/context/TelegramContext.tsx
+++ b/src/context/TelegramContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useContext, ReactNode, useEffect } from 'react';
+import React, { createContext, useState, useContext, ReactNode, useEffect, useCallback } from 'react';
 import { TelegramBot, TelegramChat, SendMessageResponse, StoredToken, ForumTopic } from '../types/telegram';
 
 interface TelegramContextType {
@@ -117,7 +117,7 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
     }
   };
 
-  const fetchChats = async (): Promise<void> => {
+  const fetchChats = useCallback(async (): Promise<void> => {
     if (!token) {
       setError('No token provided');
       return;
@@ -125,20 +125,20 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
 
     setLoading(true);
     setError(null);
-    
+
     try {
       const response = await fetch(`https://api.telegram.org/bot${token}/getUpdates`);
       const data = await response.json();
-      
+
       if (!data.ok) {
         setError(data.description || 'Failed to fetch chats');
         setLoading(false);
         return;
       }
-      
+
       // Extract unique chats from updates and collect forum topics
       const uniqueChats = new Map<number, TelegramChat>();
-      const topicsMap: Record<number, ForumTopic[]> = { ...forumTopics };
+      const topicsMap: Record<number, ForumTopic[]> = {};
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       data.result.forEach((update: any) => {
@@ -160,24 +160,25 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
       });
 
       setChats(Array.from(uniqueChats.values()));
-      setForumTopics(topicsMap);
+      setForumTopics(prev => ({ ...prev, ...topicsMap }));
       setLoading(false);
     } catch (err) {
       console.error(err);
       setError('Failed to fetch chats');
       setLoading(false);
     }
-  };
+  }, [token]);
 
-  const sendTextMessage = async (
-    chatId: number | string,
-    text: string,
-    threadId?: number,
-  ): Promise<SendMessageResponse | null> => {
-    if (!token) {
-      setError('No token provided');
-      return null;
-    }
+  const sendTextMessage = useCallback(
+    async (
+      chatId: number | string,
+      text: string,
+      threadId?: number,
+    ): Promise<SendMessageResponse | null> => {
+      if (!token) {
+        setError('No token provided');
+        return null;
+      }
 
     setLoading(true);
     setError(null);
@@ -210,18 +211,21 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
       setLoading(false);
       return null;
     }
-  };
+    },
+    [token],
+  );
 
-  const sendImageMessage = async (
-    chatId: number | string,
-    image: File,
-    caption?: string,
-    threadId?: number,
-  ): Promise<SendMessageResponse | null> => {
-    if (!token) {
-      setError('No token provided');
-      return null;
-    }
+  const sendImageMessage = useCallback(
+    async (
+      chatId: number | string,
+      image: File,
+      caption?: string,
+      threadId?: number,
+    ): Promise<SendMessageResponse | null> => {
+      if (!token) {
+        setError('No token provided');
+        return null;
+      }
 
     setLoading(true);
     setError(null);
@@ -258,7 +262,9 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
       setLoading(false);
       return null;
     }
-  };
+    },
+    [token],
+  );
 
   const clearData = () => {
     setToken('');

--- a/src/context/TelegramContext.tsx
+++ b/src/context/TelegramContext.tsx
@@ -149,11 +149,12 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
           if (update.message.message_thread_id) {
             const threadId = update.message.message_thread_id as number;
             const name = update.message.forum_topic_created?.name as string | undefined;
+            const title = update.message.chat?.title;
             if (!topicsMap[chat.id]) {
               topicsMap[chat.id] = [];
             }
             if (!topicsMap[chat.id].some(t => t.message_thread_id === threadId)) {
-              topicsMap[chat.id].push({ message_thread_id: threadId, name });
+              topicsMap[chat.id].push({ message_thread_id: threadId, name, title });
             }
           }
         }

--- a/src/context/TelegramContext.tsx
+++ b/src/context/TelegramContext.tsx
@@ -108,7 +108,8 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
       addStoredToken(token, data.result);
       setLoading(false);
       return true;
-    } catch (error) {
+    } catch (err) {
+      console.error(err);
       setError('Failed to verify token');
       setBotInfo(null);
       setLoading(false);
@@ -139,6 +140,7 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
       const uniqueChats = new Map<number, TelegramChat>();
       const topicsMap: Record<number, ForumTopic[]> = { ...forumTopics };
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       data.result.forEach((update: any) => {
         if (update.message && update.message.chat) {
           const chat = update.message.chat;
@@ -160,7 +162,8 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
       setChats(Array.from(uniqueChats.values()));
       setForumTopics(topicsMap);
       setLoading(false);
-    } catch (error) {
+    } catch (err) {
+      console.error(err);
       setError('Failed to fetch chats');
       setLoading(false);
     }
@@ -201,7 +204,8 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
       }
       
       return data;
-    } catch (error) {
+    } catch (err) {
+      console.error(err);
       setError('Failed to send message');
       setLoading(false);
       return null;
@@ -248,7 +252,8 @@ export const TelegramProvider: React.FC<{ children: ReactNode }> = ({ children }
       }
       
       return data;
-    } catch (error) {
+    } catch (err) {
+      console.error(err);
       setError('Failed to send image');
       setLoading(false);
       return null;

--- a/src/types/telegram.ts
+++ b/src/types/telegram.ts
@@ -38,6 +38,7 @@ export interface SendMessageParams {
   chat_id: number | string;
   text: string;
   parse_mode?: 'HTML' | 'MarkdownV2' | 'Markdown';
+  message_thread_id?: number;
 }
 
 export interface SendPhotoParams {
@@ -45,6 +46,7 @@ export interface SendPhotoParams {
   photo: File;
   caption?: string;
   parse_mode?: 'HTML' | 'MarkdownV2' | 'Markdown';
+  message_thread_id?: number;
 }
 
 export interface SendMessageResponse {
@@ -63,4 +65,9 @@ export interface StoredToken {
   token: string;
   botInfo: TelegramBot;
   addedAt: number;
+}
+
+export interface ForumTopic {
+  message_thread_id: number;
+  name?: string;
 }

--- a/src/types/telegram.ts
+++ b/src/types/telegram.ts
@@ -70,4 +70,6 @@ export interface StoredToken {
 export interface ForumTopic {
   message_thread_id: number;
   name?: string;
+  title?: string;
+  
 }


### PR DESCRIPTION
## Summary
- support sending messages to specific threads
- track supergroup threads from updates
- expose forum topics in Telegram context
- allow choosing thread ID in MessageForm

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_685175e128188330872ce4cbcf905b1b